### PR TITLE
docs: iterate rich-cli-tools spec — three-subpackage layout, Rich-only dep

### DIFF
--- a/docs/project/specs/active/plan-2026-05-23-rich-cli-tools.md
+++ b/docs/project/specs/active/plan-2026-05-23-rich-cli-tools.md
@@ -4,7 +4,7 @@ description: New standalone package for Python terminal UX — Rich enhancements
 ---
 # Feature: `rich-cli-tools` — A Focused Terminal UX Package for Python CLIs
 
-**Date:** 2026-05-23 (last updated 2026-05-23)
+**Date:** 2026-05-23 (last updated 2026-06-12)
 
 **Author:** Joshua Levy
 
@@ -13,23 +13,31 @@ description: New standalone package for Python terminal UX — Rich enhancements
 ## Overview
 
 Create a new standalone open-source repo, **`rich-cli-tools`** (PyPI name
-verified available as of this writing), consolidating all the generic
-terminal/CLI user-experience utilities currently scattered across
-**kash** (`utils/rich_custom/`, `config/unified_live.py`,
+verified available), consolidating the generic terminal/CLI
+user-experience utilities currently scattered across **kash**
+(`utils/rich_custom/`, `config/unified_live.py`,
 `shell/file_icons/nerd_icons.py`) and **clideps** (`terminal/`,
 `ui/styles.py`, `ui/rich_output.py`).
 
 The package covers everything a Python CLI needs for a polished terminal
-experience: improved Rich Markdown rendering, correct cell-width math
-with OSC-8 hyperlinks, terminal capability detection, inline images
-(sixel/kitty), live multi-task progress displays, Nerd Font file icons,
-and consistent styled output helpers.
+experience: improved Rich Markdown rendering, OSC-8-aware cell-width
+math, terminal capability detection, inline images (sixel/kitty), live
+multi-task progress displays, Nerd Font file icons, and consistent
+styled-output helpers.
 
-It is deliberately **dependency-minimal**: `rich` (which already brings
-`markdown-it-py` and `pygments`) plus at most `strif` and
-`typing-extensions`. It does **not** depend on clideps — the dependency
-will eventually flow the other way (clideps depends on rich-cli-tools
-for its terminal/UI needs, and refocuses on package/env management).
+**Internal structure documents the dependency split.** Rich is a hard
+dependency of the installed package, but the source layout makes obvious
+which modules need Rich and which don't. Two subpackages —
+`terminal/` and `icons/` — use only the stdlib; one subpackage —
+`display/` — uses Rich. This is for clarity and future flexibility,
+not for an optional install: agents and humans reading the source can
+see at a glance which utilities are about the terminal *emulator* (OSC
+codes, capabilities, images) versus *Rich's rendering layer*.
+
+The package depends on `rich`, `strif`, and `typing-extensions`; it
+does **not** depend on clideps — the dependency will eventually flow
+the other way (clideps becomes a *consumer* of this package and
+refocuses on package/env management).
 
 The repo also ships a **companion agent skill** (`SKILL.md`, Agent
 Skills open standard) so that coding agents asked to "build a Python
@@ -37,7 +45,7 @@ CLI" can discover the package and follow a menu of high-quality UX
 patterns.
 
 This spec is written to be handed to an agent and implemented
-end-to-end: repo scaffolding from the `simple-modern-uv` template,
+end-to-end: scaffolding from the `simple-modern-uv` template,
 module-by-module porting with decoupling notes, tests, docs, skill,
 and publishing.
 
@@ -45,8 +53,11 @@ and publishing.
 
 - One focused package for terminal UX in Python CLIs, useful to humans
   and to agents driving CLIs
-- Near-minimal dependency surface: `rich` + `strif` +
-  `typing-extensions` only (see Dependency Policy)
+- **Explicit internal layering**: a clear, documented split between
+  dep-free terminal/data modules and Rich-dependent display modules.
+  Each module's path advertises which side it's on.
+- Minimal external dependency surface: `rich`, `strif`,
+  `typing-extensions` (see Dependency Policy)
 - No dependency on clideps, kash, or flowmark; clideps later becomes a
   *consumer* of this package
 - Scaffolded from `simple-modern-uv` (copier template) with the
@@ -85,90 +96,159 @@ and sixel/kitty image display — but clideps is really a
 package-management/env-setup tool and those pieces don't belong there
 long-term.
 
-A dependency scan confirms feasibility of the minimal-deps goal:
+### Per-module maturity (read from current source, 2026-06-12)
 
-- kash's `rich_custom/*` modules import only `rich`, `markdown_it`
-  (ships with rich), `strif`, `typing_extensions`, plus 2–3 small kash
-  config imports that are easy to inline.
-- clideps's `terminal/*` modules import only `rich` plus three tiny
-  clideps-internal helpers (`NotSupportedError`, `STYLE_HINT`,
-  `format_success_or_failure`) that move into this package alongside
-  them.
-- clideps's `ui/rich_output.py` imports `flowmark.fill_text` — the one
-  dependency to eliminate (see Dependency Policy).
+Direct review of each candidate module — git history, in-kash usage
+(production callers, excluding tests and the module itself), inline
+tests, and coupling to kash internals:
+
+| Module | LOC | Inline tests | kash coupling | Used by in kash | Maturity |
+|---|---|---|---|---|---|
+| `ansi_cell_len.py` | 74 | yes | none | 1 (doc normalization) | **Mature.** Fixes a real Rich bug (OSC-8 links break `cell_len`). Drop-in. |
+| `rich_char_transform.py` | 91 | yes | none | 0 in production* | **Mature, niche.** *Only used in-tree by the markdown fork (heading uppercasing). |
+| `rich_indent.py` (`Indent`) | 71 | none | none | 1 (shell_output) | **Mature** but lacks an inline test (trivial to add). Fills a real Rich gap (Padding is whitespace-only). |
+| `rich_markdown_fork.py` | 771 | partial | 2 style consts | 3 (welcome, kmarkdown, shell_output) | **Usable, fork-risk.** Hard fork of Rich's `markdown.py` pinned to v13.9.4 internals; uses `rich._loop`, `rich._stack` private APIs; monkey-patches `rich.markdown.Markdown` at import. Single-commit history (no churn) — works but will need maintenance when Rich's internals shift. |
+| `multitask_status.py` | 770 | yes | unified_live + progress types + text_styles | 1 (shell_output) | **Usable, moderately mature.** 3 commits; styles decoupled in commit `859424e`. Many moving parts. |
+| `unified_live.py` | 249 | none | kash logger + text_styles | 4 (shell_callable_action, custom_shell, assistant_commands) | **Heavily exercised but "magic."** Singleton that patches Rich's one-Live-at-a-time limit; never refactored. Trickiest port; highest behavior risk. |
+| `nerd_icons.py` | 946 | none | **none** | 2 (files_command, local_server_routes) | **Mature as data table.** Clean port of eza's icons with proper license attribution. Most of the LOC is icon-table data. Will slowly drift from eza upstream. |
+| `color_for_format.py` | 72 | none | Format enum + kash colors | (kash internal) | **Stays in kash** — coupled to Format enum. Not extractable. |
+| clideps `terminal/osc_utils.py` | 95 | (some) | rich only | (clideps internal) | **Mature.** Both string and Rich-Text OSC-8 variants — splits naturally between the package's two layers. |
+| clideps `terminal/terminal_features.py` | 57 | none | clideps-only | (clideps `pkg-check`) | **Mature** detection logic; Rich-coupling is only in the report-printing helper, easy to split. |
+| clideps `terminal/terminal_images.py` | 141 | none | NotSupportedError + STYLE_HINT | (clideps internal) | **Usable.** subprocess/termios-based detection + display; Rich only for an error fallback print — refactor to raise instead. |
+| clideps `ui/styles.py` | 32 | none | rich only | (clideps-wide) | **Mature** small constants file. |
+| clideps `ui/rich_output.py` | 147 | none | flowmark + clideps styles | (clideps-wide) | **Mature.** One `flowmark.fill_text` call to replace (stdlib `textwrap` or Rich's wrapping). |
 
 PyPI name availability checked: `rich-cli-tools`, `richcli`, and
 `rich-terminal-tools` are all unclaimed. Working name: `rich-cli-tools`.
 
-Prior related work in this repo:
+### Ship-now vs. ship-careful (informs Phase ordering)
+
+- **Ship-now** (safe, well-tested, low coupling): `ansi_cell_len`,
+  `rich_char_transform`, `rich_indent`, `nerd_icons`, clideps's
+  `osc_utils` / `styles` / `terminal_features` (detection half).
+- **Ship-careful** (more complex; need careful test coverage):
+  `multitask_status`, `rich_markdown_fork`, `unified_live`,
+  `terminal_images`, clideps's `rich_output`.
+
+This isn't a hard tier separation — all of these ship in v0.1 — but it
+informs the implementation phase ordering and where to focus
+tryscript golden tests.
+
+### Prior related work in this repo
 
 - `plan-2026-05-23-utility-extraction.md` — the full extraction menu;
   this spec implements its Phase C (terminal/Rich package) and the
   movement half of Phase D (clideps trim), with the explicit decision
   that the new package does NOT depend on gather-limited.
-- Commit `859424e` — decoupled progress symbols into injectable
-  `ProgressSymbols`, preparing `multitask_status` for extraction.
+- Commit `859424e` (merged via PR #7) — decoupled progress symbols into
+  injectable `ProgressSymbols`, preparing `multitask_status` for
+  extraction.
 
 ## Design
 
 ### Repo layout
 
-Scaffolded from `simple-modern-uv` (see Scaffolding below), with this
-package structure:
+Scaffolded from `simple-modern-uv` (see Scaffolding below), with three
+internal subpackages that document the dependency split:
+
+- **`terminal/`** — pure stdlib. Anything about the terminal emulator
+  itself (escape codes, capability detection, image subprocess).
+- **`icons/`** — pure stdlib. Pure data tables and a lookup function.
+- **`display/`** — Rich-required. Everything that builds on Rich's
+  rendering layer.
+
+Plus two top-level modules (`errors.py`, `progress_types.py`) that span
+the layers — both stdlib-only.
 
 ```
 rich-cli-tools/
-├── pyproject.toml              # from template; deps: rich, strif, typing-extensions
-├── README.md                   # with embedded demo screenshots
+├── pyproject.toml                  # from template; deps: rich (only)
+├── README.md                       # with embedded demo screenshots/asciinema
 ├── src/rich_cli_tools/
-│   ├── __init__.py             # curated public API re-exports
-│   ├── cells.py                # ansi_cell_len: OSC-8-aware cell-width fix
-│   ├── char_transform.py       # span-preserving case transforms for rich.Text
-│   ├── indent.py               # Indent renderable (arbitrary string prefix)
-│   ├── markdown.py             # improved Markdown renderer (opt-in patch, see below)
-│   ├── osc.py                  # OSC-8 hyperlinks (from clideps osc_utils)
-│   ├── term_features.py        # terminal capability detection (from clideps)
-│   ├── term_images.py          # sixel/kitty inline images (from clideps)
-│   ├── styles.py               # neutral style constants (merged kash+clideps defaults)
-│   ├── output.py               # print_heading/print_error/print_warning/
-│   │                           #   format_success_or_failure (from clideps rich_output)
-│   ├── progress_types.py       # TaskState/TaskInfo/TaskSummary/ProgressSymbols
-│   │                           #   (vendored from kash progress_protocol; stdlib-only)
-│   ├── multitask.py            # MultitaskStatus live display (from kash)
-│   ├── live.py                 # UnifiedLive multiplexer (from kash unified_live)
-│   ├── icons.py                # Nerd Font file icons (from kash nerd_icons)
-│   └── errors.py               # NotSupportedError + package error base
+│   ├── __init__.py                 # curated re-exports
+│   ├── errors.py                   # NotSupportedError, package base (stdlib)
+│   ├── progress_types.py           # TaskState/TaskInfo/TaskSummary/ProgressSymbols (stdlib)
+│   │
+│   ├── terminal/                   # ── pure stdlib ──
+│   │   ├── __init__.py
+│   │   ├── osc.py                  # OSC-8 hyperlink escape strings
+│   │   ├── features.py             # TerminalInfo + capability detection (data)
+│   │   └── images.py               # sixel/kitty inline image display (subprocess); raises NotSupportedError
+│   │
+│   ├── icons/                      # ── pure stdlib ──
+│   │   ├── __init__.py
+│   │   └── nerd_fonts.py           # Icons enum, lookup tables, icon_for_file()
+│   │
+│   └── display/                    # ── Rich-required ──
+│       ├── __init__.py
+│       ├── cells.py                # ansi_cell_len
+│       ├── char_transform.py       # text_upper, text_lower (Text-preserving)
+│       ├── indent.py               # Indent renderable
+│       ├── osc_rich.py             # OSC-8 wrapper returning rich.Text
+│       ├── markdown.py             # CustomMarkdown + explicit install()
+│       ├── styles.py               # neutral Rich style constants
+│       ├── output.py               # print_heading/error/warning/success + format_success_or_failure
+│       ├── live.py                 # UnifiedLive multiplexer
+│       ├── multitask.py            # MultitaskStatus live display
+│       └── features_report.py      # pretty-print TerminalInfo (Rich consumer of terminal/features)
+│
 ├── skills/
 │   └── python-cli-ux/
-│       └── SKILL.md            # companion agent skill (see Skill section)
+│       └── SKILL.md                # companion agent skill (see Skill section)
 ├── examples/
-│   ├── demo_markdown.py        # render README.md with the improved renderer
-│   ├── demo_multitask.py       # synthetic multi-task progress run
-│   ├── demo_features.py        # print terminal capability report
-│   └── demo_icons.py           # icon listing for a directory
-├── tests/                      # ported pytest suites
-└── tryscript/                  # golden CLI-output tests (ANSI-stripped)
+│   ├── demo_markdown.py            # render a sample doc with the improved renderer
+│   ├── demo_multitask.py           # synthetic multi-task progress run
+│   ├── demo_features.py            # print terminal capability report
+│   └── demo_icons.py               # icon listing for a directory
+├── tests/                          # ported pytest suites
+└── tryscript/                      # golden CLI-output tests (ANSI-stripped)
 ```
+
+The user-facing API (re-exported from `rich_cli_tools.__init__`)
+remains flat for ergonomics — the subpackage layout is for source-level
+documentation, not for forcing long import paths on consumers.
 
 ### Module inventory (source → target)
 
-| Source | LOC | Target module | Decoupling work |
-|---|---|---|---|
-| kash `utils/rich_custom/ansi_cell_len.py` | 74 | `cells.py` | None — self-contained |
-| kash `utils/rich_custom/rich_char_transform.py` | 91 | `char_transform.py` | None — self-contained |
-| kash `utils/rich_custom/rich_indent.py` | 71 | `indent.py` | None — self-contained |
-| kash `utils/rich_custom/rich_markdown_fork.py` | 771 | `markdown.py` | Inline 2 style constants from `kash.config.text_styles`; make the `rich.markdown.Markdown` monkey-patch **opt-in** via explicit `install()` (today it patches at import time, line 771) |
-| kash `utils/rich_custom/multitask_status.py` | 770 | `multitask.py` | Import emojis from own `styles.py` instead of `kash.config.text_styles`; take live-display via constructor instead of `kash.config.unified_live.get_unified_live()` (accept an optional `UnifiedLive` or plain console) |
-| kash `config/unified_live.py` | 249 | `live.py` | Replace `kash.config.logger.get_console` with injectable console (default `rich.get_console()`); inline 2 spinner/color constants |
-| kash `shell/file_icons/nerd_icons.py` | 946 | `icons.py` | None — self-contained (stdlib only) |
-| kash `utils/api_utils/progress_protocol.py` (types only) | ~150 of 316 | `progress_types.py` | Vendor `TaskState`, `TaskInfo`, `TaskSummary`, `ProgressSymbols`. Do NOT vendor `ProgressTracker` Protocol / `SimpleProgressTracker` (they stay with the future gather-limited package; see interop note) |
-| clideps `terminal/osc_utils.py` | 95 | `osc.py` | None — imports only rich |
-| clideps `terminal/terminal_features.py` | 57 | `term_features.py` | Update imports to this package's `output.py` |
-| clideps `terminal/terminal_images.py` | 141 | `term_images.py` | `NotSupportedError` moves to `errors.py`; `STYLE_HINT` from own `styles.py` |
-| clideps `ui/styles.py` | 32 | `styles.py` | Merge with neutral defaults needed by multitask/markdown |
-| clideps `ui/rich_output.py` | 147 | `output.py` | **Remove `flowmark.fill_text` dependency** — replace with a local simple fill using Rich's own `Text.wrap`/`console.width`, or stdlib `textwrap` (fill_text is used in exactly one function) |
+Grouped by target subpackage so the dependency split is self-evident.
 
-**Explicitly not ported:**
+#### `terminal/` — pure stdlib, no Rich import
+
+| Source | LOC | Target | Decoupling |
+|---|---|---|---|
+| clideps `terminal/osc_utils.py` (string-only half) | ~50 of 95 | `terminal/osc.py` | Split: keep the OSC-8 string builders here; move the `osc8_link_rich(...) -> rich.Text` wrapper to `display/osc_rich.py` |
+| clideps `terminal/terminal_features.py` (detection half) | ~30 of 57 | `terminal/features.py` | Split: keep `TerminalInfo` dataclass + the capability-detection logic (env vars, TTY checks) here. Move the report-printing function to `display/features_report.py`. |
+| clideps `terminal/terminal_images.py` | 141 | `terminal/images.py` | Drop the `STYLE_HINT` printing fallback — `display_image()` returns on success, raises `NotSupportedError` on failure with a useful message. Callers decide how to print errors. |
+
+#### `icons/` — pure stdlib, no Rich import
+
+| Source | LOC | Target | Decoupling |
+|---|---|---|---|
+| kash `shell/file_icons/nerd_icons.py` | 946 | `icons/nerd_fonts.py` | None — already zero-coupling stdlib. Add a basic test for `icon_for_file()` over a fixture set of common filenames (currently has no tests). |
+
+#### Top-level (stdlib only, span both layers)
+
+| Source | LOC | Target | Decoupling |
+|---|---|---|---|
+| clideps `errors.py` (`NotSupportedError`) | ~5 | `errors.py` | Move; add a package base class if useful |
+| kash `utils/api_utils/progress_protocol.py` (types subset) | ~80 of 316 | `progress_types.py` | Vendor `TaskState`, `TaskInfo`, `TaskSummary`, `ProgressSymbols`. Do **not** vendor `ProgressTracker` Protocol / `SimpleProgressTracker` — they belong with the future gather-limited package (see interop note). |
+
+#### `display/` — Rich-required
+
+| Source | LOC | Target | Decoupling |
+|---|---|---|---|
+| kash `utils/rich_custom/ansi_cell_len.py` | 74 | `display/cells.py` | None — already self-contained |
+| kash `utils/rich_custom/rich_char_transform.py` | 91 | `display/char_transform.py` | None — already self-contained |
+| kash `utils/rich_custom/rich_indent.py` | 71 | `display/indent.py` | Add an inline test (currently none) |
+| clideps `terminal/osc_utils.py` (Rich half) | ~45 of 95 | `display/osc_rich.py` | Just the `osc8_link_rich(...) -> rich.Text` wrapper; depends on `terminal/osc.py` for the escape string |
+| clideps `ui/styles.py` | 32 | `display/styles.py` | Merge with neutral defaults needed by multitask/markdown |
+| clideps `ui/rich_output.py` | 147 | `display/output.py` | **Replace `flowmark.fill_text` with stdlib `textwrap.fill` or Rich's own wrapping** (used in exactly one function). |
+| clideps `terminal/terminal_features.py` (report half) | ~27 of 57 | `display/features_report.py` | Pretty-print a `TerminalInfo` (consumes the dataclass from `terminal/features.py`). |
+| kash `utils/rich_custom/rich_markdown_fork.py` | 771 | `display/markdown.py` | Inline 2 style constants from `kash.config.text_styles`; make the `rich.markdown.Markdown` monkey-patch **opt-in** via an explicit `install()` call (today it patches at import time, line 771). Pin a minimum rich version and add a CI canary test that fails loudly when a new rich release breaks the fork (it uses `rich._loop`, `rich._stack` private APIs). |
+| kash `config/unified_live.py` | 249 | `display/live.py` | Replace `kash.config.logger.get_console` with injectable console (default `rich.get_console()`); inline 2 spinner/color constants; **replace `strif.AtomicVar` with `threading.Lock` + plain variable** (small refactor) |
+| kash `utils/rich_custom/multitask_status.py` | 770 | `display/multitask.py` | Take live-display via constructor instead of `kash.config.unified_live.get_unified_live()` (accept optional `UnifiedLive` or plain console). Emojis already injectable via `ProgressSymbols` (commit `859424e`). **Inline `strif.abbrev_str` and `strif.single_line`** (each ~5 lines) into a small `_internal.py` or directly into the module. |
+
+#### Explicitly not ported
 
 - kash `shell/file_icons/color_for_format.py` (72 LOC) — coupled to
   kash's `Format` enum; stays in kash
@@ -176,60 +256,86 @@ rich-cli-tools/
   `kerm_codes.py` — Kerm protocol is its own future decision
 - kash `config/text_styles.py` and `config/colors.py` — kash branding;
   only the handful of neutral constants used by ported modules are
-  inlined into `styles.py`
+  inlined into `display/styles.py`
 
 ### Dependency policy
 
-**Allowed:** `rich` (brings `markdown-it-py` + `pygments` transitively —
-so the markdown renderer costs nothing extra), `strif` (used by
-`multitask.py` for `abbrev_str`/`single_line` and `live.py` for
-`AtomicVar`; small, zero-dep, author-owned), `typing-extensions`
-(for `override` on Python 3.11).
+**Only one runtime dependency: `rich`.**
 
-**Excluded, with the replacement strategy:**
+Rich already brings `markdown-it-py` and `pygments` transitively, so
+the markdown renderer costs nothing extra. Everything else uses the
+stdlib. This means the package installs as cleanly as Rich itself does.
 
-- `flowmark` → replace the single `fill_text` call in `output.py` with
-  stdlib/Rich wrapping
-- `clideps` → the needed pieces move *into* this package
-- `gather-limited` (future) → see interop note below
-- `prettyfmt` → not currently needed by any ported module; allowed
-  later if a real need appears, but v0.1 ships without it
+| Dep | Status | Notes |
+|---|---|---|
+| `rich` | required | The headline dep; used by every `display/*` module. `terminal/*` and `icons/*` never import it. |
+| `markdown-it-py` | transitive (via rich) | Used by `display/markdown.py` |
+| `pygments` | transitive (via rich) | Used by `display/markdown.py` for code fence highlighting |
+| `strif` | **removed** | Replaced with stdlib: `AtomicVar` → `threading.Lock` + variable in `display/live.py`; `abbrev_str` / `single_line` → small inline helpers in `display/multitask.py` |
+| `typing-extensions` | **removed** | Replaced with `try: from typing import override; except ImportError: def override(f): return f` (stdlib path on Python 3.12+, no-op shim on 3.11) |
+| `flowmark` | **removed** | The single `fill_text` call in `display/output.py` is replaced by stdlib `textwrap.fill` or Rich's wrapping |
+| `clideps` | excluded | Pieces move *into* this package |
+| `gather-limited` (future) | excluded | See interop note |
+| `prettyfmt` | excluded | Not currently needed by any ported module |
 
-**gather-limited interop note:** `multitask.py` implements the
-`ProgressTracker` protocol that the future `gather-limited` package
-will define. Because `ProgressTracker` is a `typing.Protocol`
-(structural), `MultitaskStatus` satisfies it without importing it —
-no dependency needed in either direction. The one nominal type that
-crosses the boundary is the `TaskState` enum: vendored here in
-`progress_types.py` and (eventually) in gather-limited. To keep the two
-enums interoperable, `multitask.py` MUST compare states by `.value`
-(string), not by identity. Document this contract in both packages.
-If this proves awkward in practice, the fallback is a
-`rich-cli-tools[gather]` extra plus a thin adapter — decide after
-gather-limited ships.
+**Test-time deps** (`dev` group): pytest, ruff, basedpyright, codespell
+per simple-modern-uv defaults; plus tryscript invoked via
+`npx tryscript@latest` (no install needed).
+
+### gather-limited interop note
+
+`display/multitask.py` implements the `ProgressTracker` protocol that
+the future `gather-limited` package will define. Because
+`ProgressTracker` is a `typing.Protocol` (structural),
+`MultitaskStatus` satisfies it without importing it — no dependency
+needed in either direction. The one nominal type that crosses the
+boundary is the `TaskState` enum: vendored here in `progress_types.py`
+and (eventually) in gather-limited. To keep the two enums
+interoperable, `display/multitask.py` MUST compare states by `.value`
+(string), not by identity. Document this contract in both packages. If
+it proves awkward, the fallback is a `rich-cli-tools[gather]` extra
+plus a thin adapter — decide after gather-limited ships.
 
 ### Public API (`__init__.py`)
 
-Curate a small, documented surface (everything else importable from
-submodules but not re-exported):
+Curated re-exports keep import paths short for typical use:
 
 ```python
-from rich_cli_tools.cells import ansi_cell_len
-from rich_cli_tools.char_transform import text_upper, text_lower  # (actual names per port)
-from rich_cli_tools.indent import Indent
-from rich_cli_tools.markdown import CustomMarkdown, install as install_markdown
-from rich_cli_tools.osc import osc8_link, osc8_link_rich, terminal_supports_osc8
-from rich_cli_tools.term_features import TerminalInfo, detect_terminal_features
-from rich_cli_tools.term_images import display_image, terminal_supports_sixel
-from rich_cli_tools.output import (
+# Top-level (stdlib)
+from rich_cli_tools.errors import NotSupportedError
+from rich_cli_tools.progress_types import (
+    TaskState, TaskInfo, TaskSummary, ProgressSymbols,
+)
+
+# terminal/ (stdlib)
+from rich_cli_tools.terminal.osc import osc8_link, terminal_supports_osc8
+from rich_cli_tools.terminal.features import TerminalInfo, detect_terminal_features
+from rich_cli_tools.terminal.images import display_image, terminal_supports_sixel
+
+# icons/ (stdlib)
+from rich_cli_tools.icons.nerd_fonts import icon_for_file, Icons
+
+# display/ (Rich)
+from rich_cli_tools.display.cells import ansi_cell_len
+from rich_cli_tools.display.char_transform import text_upper, text_lower
+from rich_cli_tools.display.indent import Indent
+from rich_cli_tools.display.osc_rich import osc8_link_rich
+from rich_cli_tools.display.markdown import CustomMarkdown, install as install_markdown
+from rich_cli_tools.display.output import (
     print_heading, print_error, print_warning, print_success,
     format_success_or_failure,
 )
-from rich_cli_tools.progress_types import TaskState, TaskInfo, TaskSummary, ProgressSymbols
-from rich_cli_tools.multitask import MultitaskStatus, StatusSettings, StatusStyles
-from rich_cli_tools.live import UnifiedLive
-from rich_cli_tools.icons import icon_for_file, Icons
+from rich_cli_tools.display.live import UnifiedLive
+from rich_cli_tools.display.multitask import (
+    MultitaskStatus, StatusSettings, StatusStyles,
+)
+from rich_cli_tools.display.features_report import print_terminal_features
 ```
+
+The top-level `__init__.py` re-exports the most-used symbols so callers
+can write `from rich_cli_tools import ansi_cell_len, Indent, ...` for
+common cases. The subpackage paths remain the canonical home and are
+the form shown in docs / the skill.
 
 ### Scaffolding from simple-modern-uv
 
@@ -300,63 +406,104 @@ and the `cli-agent-skill-patterns` guideline:
 
 ## Implementation Plan
 
-Single repo, ordered checklist. Steps 1–3 are sequential; 4–8 can be
-done module-by-module in any order; 9–12 are sequential.
+Single repo, ordered phases. Phase 1 is sequential prerequisite;
+Phases 2–4 can be done in parallel by module; Phases 5–7 are
+sequential.
 
 ### Phase 1: Scaffold and verify
 
 - [ ] Create GitHub repo `jlevy/rich-cli-tools`
-- [ ] Scaffold from simple-modern-uv via copier (answers above)
+- [ ] Scaffold from simple-modern-uv via copier (answers below)
+- [ ] Set `pyproject.toml` dependencies to `rich` only
+- [ ] Create subpackage skeletons: `src/rich_cli_tools/{terminal,icons,display}/__init__.py`
 - [ ] `make install && make lint && make test` passes on placeholder
 - [ ] CI green on first push
 - [ ] `tbd setup --auto --prefix=<chosen>` in the new repo
 
-### Phase 2: Port the self-contained leaf modules
+### Phase 2: Port the stdlib-only modules (no Rich needed)
 
-- [ ] `cells.py`, `char_transform.py`, `indent.py`, `icons.py`,
-      `osc.py` — direct copies with import-path updates only
-- [ ] Port their inline tests into `tests/`
-- [ ] `errors.py` with `NotSupportedError`
-- [ ] `styles.py` — merged neutral constants (audit exactly which
-      constants the other modules need; keep it under ~40 lines)
+These ship first because they have no decoupling work and no Rich-bug
+surface area. Includes a CI rule that fails the build if any module
+under `terminal/` or `icons/` imports `rich`.
 
-### Phase 3: Port modules with light decoupling
+- [ ] `terminal/osc.py` — string-only OSC-8 builders + capability check
+- [ ] `terminal/features.py` — `TerminalInfo` dataclass + detection logic
+- [ ] `terminal/images.py` — sixel/kitty subprocess display; refactor
+      `STYLE_HINT` fallback into `raise NotSupportedError(...)`
+- [ ] `icons/nerd_fonts.py` — direct copy of `nerd_icons.py`
+- [ ] `errors.py` — `NotSupportedError` + package base
+- [ ] `progress_types.py` — vendor `TaskState`, `TaskInfo`,
+      `TaskSummary`, `ProgressSymbols`; document compare-by-value
+      contract for `TaskState`
+- [ ] Tests:
+  - port existing inline tests where they exist
+  - **add** `icon_for_file()` fixture test (no current coverage)
+  - **add** `terminal/features.py` test with env-var fakes
+- [ ] CI lint rule: `grep -r "import rich\|from rich" src/rich_cli_tools/{terminal,icons}/ && exit 1`
 
-- [ ] `output.py` from clideps `rich_output.py` — replace
-      `flowmark.fill_text` with stdlib/Rich wrapping; verify identical
-      output on test strings of varied width
-- [ ] `term_features.py`, `term_images.py` — re-point internal imports
-- [ ] `markdown.py` — inline style constants; convert import-time
-      monkey-patch to explicit `install()`; add docstring explaining
-      when to call it
-- [ ] `progress_types.py` — vendor the four types; document the
-      compare-by-value contract for `TaskState`
+### Phase 3: Port the self-contained Rich modules
 
-### Phase 4: Port the live-display modules
+The "ship-now" tier from the Background maturity table. Direct copies,
+import-path updates, minor inlining.
 
-- [ ] `live.py` from kash `unified_live.py` — injectable console
-- [ ] `multitask.py` from kash `multitask_status.py` — emojis from own
-      `styles.py`; live-display injection; port the 4 inline tests
-- [ ] Integration test: `MultitaskStatus` driving a synthetic batch of
-      async tasks (port relevant parts of kash's
-      `test_multitask_status.py`, minus the gather-limited-coupled
-      cases, which stay in kash until gather-limited ships)
+- [ ] `display/cells.py` from `ansi_cell_len.py` — direct copy
+- [ ] `display/char_transform.py` from `rich_char_transform.py` — direct copy
+- [ ] `display/indent.py` from `rich_indent.py` — direct copy + **add an inline test**
+- [ ] `display/osc_rich.py` from clideps `osc_utils.py` Rich half — depends on `terminal/osc.py`
+- [ ] `display/styles.py` — merge neutral constants from clideps `ui/styles.py` + the 2 from `kash.config.text_styles` needed by markdown + multitask defaults; keep under ~40 lines
+- [ ] `display/features_report.py` from clideps `terminal_features.py` report half — consumes `terminal/features.py`
+- [ ] `display/output.py` from clideps `rich_output.py` — **replace `flowmark.fill_text` with `textwrap.fill` or Rich's wrapping**; verify identical output on width-varied test strings
+
+### Phase 4: Port the heavier Rich modules
+
+The "ship-careful" tier. Each gets extra test coverage.
+
+- [ ] `display/markdown.py` from `rich_markdown_fork.py`:
+  - inline 2 style constants
+  - convert import-time monkey-patch to explicit `install()` call
+  - add a docstring explaining when to call `install()`
+  - pin a minimum rich version in `pyproject.toml`
+  - **canary test**: imports `rich.markdown` private internals
+    (`rich._loop`, `rich._stack`); a missing or renamed symbol fails
+    the build loudly (intentional CI signal when a new rich release
+    breaks the fork)
+- [ ] `display/live.py` from `unified_live.py`:
+  - replace `kash.config.logger.get_console` with injectable console
+    (default `rich.get_console()`)
+  - inline 2 spinner/color constants
+  - **replace `strif.AtomicVar` with `threading.Lock` + variable**
+- [ ] `display/multitask.py` from `multitask_status.py`:
+  - emojis already injectable via `ProgressSymbols` (commit `859424e`)
+  - take live-display via constructor instead of
+    `get_unified_live()` (accept optional `UnifiedLive` or plain console)
+  - **replace `strif.abbrev_str` + `single_line` with small inline
+    helpers** (each ~5 LOC)
+  - port the inline test set; integration test driving a synthetic
+    async batch (port relevant parts of kash's
+    `test_multitask_status.py`, minus the gather-limited-coupled
+    cases)
 
 ### Phase 5: Examples, golden tests, docs
 
-- [ ] `examples/demo_*.py` (markdown, multitask, features, icons)
-- [ ] tryscript golden tests: run each demo, strip ANSI, compare to
-      checked-in golden output (normalize terminal width via
-      `COLUMNS=80`); `NO_COLOR=1` variants
-- [ ] README: what/why, install, 4 short usage snippets, screenshot or
-      asciinema of the multitask demo
-- [ ] Verify against kash baseline: for `cells`, `char_transform`,
-      `markdown`, run the same fixture inputs through kash's originals
-      and the ported versions; outputs must be byte-identical
+- [ ] `examples/demo_markdown.py`, `demo_multitask.py`,
+      `demo_features.py`, `demo_icons.py`
+- [ ] **tryscript golden tests** under `tryscript/`:
+  - each demo run under `COLUMNS=80 NO_COLOR=` and ANSI-stripped;
+    output committed as golden
+  - extra `NO_COLOR=1` variant per demo to verify graceful degradation
+  - use `[..]` / `...` elisions for unstable spans (timings)
+- [ ] **Byte-identical port verification** (one-time): for `cells`,
+      `char_transform`, `indent`, `markdown`, `output`, run the same
+      fixture inputs through kash's originals and the ported versions;
+      diff must be empty
+- [ ] README: what/why, install, 4 short usage snippets, asciinema
+      of the multitask demo
+- [ ] Internal architecture doc covering the three-subpackage split
+      and the rule "no Rich imports in `terminal/` or `icons/`"
 
 ### Phase 6: Skill
 
-- [ ] Write `skills/python-cli-ux/SKILL.md` per the design above
+- [ ] Write `skills/python-cli-ux/SKILL.md` per the design below
 - [ ] Validate activation description against the
       `cli-agent-skill-patterns` checklist (what it does + when to use)
 - [ ] Test: in a scratch project, install the skill and confirm an
@@ -371,9 +518,9 @@ done module-by-module in any order; 9–12 are sequential.
 
 ### Phase 8: Consumer migration (separate PRs, can lag)
 
-- [ ] kash: add dep, shim modules, run full kash test suite, one
-      release with shims, then remove shims
-- [ ] clideps: add dep, shim modules, drop flowmark dep, tryscript
+- [ ] kash: add dep, shim modules at the old paths, run full kash test
+      suite; one release with shims; following release: remove shims
+- [ ] clideps: add dep, shim modules, **drop flowmark dep**; tryscript
       golden of `clideps` CLI output before/after must be identical
 - [ ] Update `plan-2026-05-23-utility-extraction.md` Phase C/D status
 
@@ -383,15 +530,24 @@ Per the golden-testing guidelines (console-output capture strategy):
 
 - **pytest**: all inline tests from kash/clideps move with their
   modules. Target: no module ships with fewer tests than it had in its
-  source repo.
+  source repo. New tests required: `icon_for_file()`,
+  `terminal/features.py` env-var detection, `display/indent.py` inline test.
+- **Layer-isolation CI check**: a grep step in CI that fails the build
+  if any module under `terminal/` or `icons/` imports `rich`. This
+  enforces the dep-free contract on those subpackages.
 - **tryscript golden tests** (`tryscript/` dir): each `examples/demo_*`
   run under `COLUMNS=80 NO_COLOR=` and ANSI-stripped, output committed
   as golden. Catches structural drift (wrong columns, missing lines,
   changed markdown layout) through every future refactor. Use
-  `[..]`/`...` elisions for unstable spans (timings).
+  `[..]`/`...` elisions for unstable spans (timings). Plus a
+  `NO_COLOR=1` variant per demo.
 - **Byte-identical port verification** (one-time, Phase 5): fixture
   inputs through old (kash) and new implementations; diff must be
   empty. This is the core migration-safety check.
+- **Markdown-fork canary** (Phase 4): an import-only test that touches
+  the private Rich symbols the fork uses (`rich._loop.loop_first`,
+  `rich._stack.Stack`); a CI failure here signals a Rich-internals
+  break before any user-visible bug ships.
 - **Visual smoke** (manual, documented in development.md): run
   `demo_multitask.py` in a real terminal, eyeball spinners/colors;
   not in CI.
@@ -412,21 +568,25 @@ Per the golden-testing guidelines (console-output capture strategy):
 ## Open Questions
 
 - **Final name**: `rich-cli-tools` (available, descriptive) vs
-  `richcli` (shorter, available). Owner picks before Phase 1.
-- **`icons.py` placement**: 946 LOC of Nerd Font tables is ~40% of the
-  package by volume. Ship in core (it's stdlib-only, costs nothing at
-  import if not used) or as `rich-cli-tools[icons]` extra? Recommend
-  core for simplicity.
-- **`markdown.py` fork maintenance**: the fork tracks Rich's Markdown
-  internals. Pin a minimum rich version and add a CI canary test that
-  fails loudly when a new rich release breaks the fork? Recommended.
-- **Upstream contributions**: several pieces (cell-width fix,
-  dashes-as-bullets option) could be PR'd to Rich itself over time;
-  carrying them here is the pragmatic interim. Track as future beads
-  in the new repo.
-- **Python floor**: template default `>=3.11,<4.0` matches kash;
-  lowering to 3.10 would require reworking `typing.TypeAlias` usage —
-  not worth it. Confirm 3.11.
+  `richcli` (shorter, available). Owner picks before Phase 1. The
+  name slightly under-describes the `terminal/` and `icons/`
+  subpackages (which don't require Rich) but signals the dominant
+  use case.
+- **Subpackage names**: `terminal/`, `icons/`, `display/` are the
+  working names. `display/` is a deliberate choice over `rich/`
+  (would shadow `import rich`). Other candidates: `ui/`, `ext/`.
+  Owner sanity-check before Phase 1.
+- **Public API surface in top-level `__init__.py`**: re-export
+  everything, or only the most commonly-used symbols? Recommendation:
+  re-export the common path (cell_len, Indent, CustomMarkdown,
+  print_*, MultitaskStatus, icon_for_file) — the canonical home is
+  the subpackage path.
+- **Upstream contributions to Rich**: several pieces (cell-width fix,
+  dashes-as-bullets option, arbitrary-prefix indent) could be PR'd
+  to Rich itself over time; carrying them here is the pragmatic
+  interim. Track as future beads in the new repo.
+- **Python floor**: template default `>=3.11,<4.0` matches kash.
+  Confirm 3.11. The `override` decorator shim makes 3.11 painless.
 
 ## References
 


### PR DESCRIPTION
## Summary

Iterate on the rich-cli-tools spec following feedback that (a) I'd planned the layout from survey reports without reading the `rich_custom/*` source directly, (b) the original flat layout conflated terminal-specific and Rich-specific modules, and (c) the dependency surface could be tighter.

### What changed

- **Three subpackages document the dep split**: `terminal/` (stdlib only — OSC escapes, capability detection, sixel/kitty subprocess), `icons/` (stdlib only — Nerd Font tables and lookup), `display/` (Rich-required — all rendering enhancements). Plus two top-level stdlib modules (`errors`, `progress_types`) that span the layers.
- **Single runtime dependency: `rich`.** Drops `strif` (`AtomicVar` → `threading.Lock`; `abbrev_str`/`single_line` → inline helpers), `typing-extensions` (`override` → stdlib-or-shim), and `flowmark` (`fill_text` → `textwrap.fill`).
- **Per-module maturity table** grounded in current source — git history, in-kash usage, coupling, inline tests. Splits the ports into a ship-now tier (cells, char_transform, indent, nerd_icons, clideps osc/styles) and a ship-careful tier (markdown_fork, multitask_status, unified_live, terminal_images, rich_output) with explicit risk notes (markdown fork uses Rich private internals).
- **CI lint rule**: build fails if any module under `terminal/` or `icons/` imports `rich` — enforces the dep-free contract.
- **Markdown-fork canary test**: imports the private Rich symbols the fork relies on (`rich._loop.loop_first`, `rich._stack.Stack`); a CI failure here signals a Rich-internals break before any user-visible bug ships.
- Implementation phases reorganized to match the new layout. Beads for Phases 2–4 retitled.

### What's unchanged

- Scaffolding from `simple-modern-uv`, the companion agent skill design, tryscript golden testing, byte-identical port verification, the kash + clideps consumer migration plan, and the gather-limited interop note (`TaskState` compare-by-value contract).

### Note

This is a docs-only PR (spec iteration). No code changes; existing beads continue to track implementation.

## Test plan

- [x] Spec renders cleanly (608 lines, structured outline verified)
- [x] Bead links remain valid via `tbd list --spec docs/project/specs/active/plan-2026-05-23-rich-cli-tools.md` (9 beads, dependency graph intact)
- [x] Phase 2–4 bead titles updated to match new structure

https://claude.ai/code/session_01ASsBTDGgzLRb3C5Aj5wkJW

---
_Generated by [Claude Code](https://claude.ai/code/session_01ASsBTDGgzLRb3C5Aj5wkJW)_