### PR TITLE
Auto-create GitHub Releases for every PyPI release; idempotent publish

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,0 +1,41 @@
+name: Create GitHub Release
+
+# Utility: create a GitHub Release page for an EXISTING tag, using the annotated
+# tag's message as the release notes. Used to backfill Release pages when a
+# release was published via tag + workflow_dispatch (see docs/publishing.md).
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag (vX.Y.Z)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (official GitHub action)
+        # Pinned to a full commit SHA (see supply-chain notes in
+        # docs/development.md); bump deliberately when updating.
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Create release from annotated tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ inputs.tag }}"
+          git tag -l --format='%(contents)' "$TAG" > /tmp/release-notes.md
+          if ! [ -s /tmp/release-notes.md ]; then
+            echo "No annotated tag message found for $TAG" && exit 1
+          fi
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 || \
+            gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --title "$TAG" \
+              --notes-file /tmp/release-notes.md --verify-tag

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
 
     permissions:
       id-token: write # Mandatory for OIDC.
-      contents: read
+      contents: write # To auto-create the GitHub Release from the tag.
   
     steps:
       - name: Checkout (official GitHub action)
@@ -59,7 +59,24 @@ jobs:
         run: uv build --no-build-isolation
 
       - name: Publish to PyPI
-        run: uv publish --trusted-publishing always
+        # --check-url makes re-runs idempotent: files already on PyPI are skipped
+        # instead of failing the run.
+        run: uv publish --trusted-publishing always --check-url https://pypi.org/simple/
+
+      - name: Create GitHub release from tag (if missing)
+        # Every PyPI release must have a matching GitHub Release. When triggered by
+        # a release this is a no-op; when dispatched on a tag (the no-gh fallback in
+        # docs/publishing.md), this creates the Release with the annotated tag's
+        # message as its notes.
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          git tag -l --format='%(contents)' "$TAG" > /tmp/release-notes.md
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 || \
+            gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --title "$TAG" \
+              --notes-file /tmp/release-notes.md --verify-tag
         # Although uv is newer and faster, the "official" publishing option is the one from PyPA,
         # which uses twine. If desired, replace `uv publish` with a reviewed full SHA:
         # uses: pypa/gh-action-pypi-publish@FULL_COMMIT_SHA # reviewed release/v1 commit

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -195,9 +195,12 @@ template).
    ```
 
    Then trigger `publish.yml` on the tag ref via the GitHub Actions UI or API
-   (`workflow_dispatch` is enabled). A Releases-page entry can be added from the
-   existing tag later; if that re-fires `publish.yml`, the duplicate run fails
-   harmlessly on "file already exists".
+   (`workflow_dispatch` is enabled). The workflow publishes to PyPI and then
+   auto-creates the matching GitHub Release from the annotated tag's message, so
+   every PyPI release has a Release page either way. To backfill a Release page
+   for an older tag, dispatch `github-release.yml` with the tag as input.
+   Publishing is idempotent (`--check-url`), so re-runs never fail on existing
+   files.
 
 3. **Confirm on PyPI, scriptably** (the JSON API updates within ~a minute):
 


### PR DESCRIPTION
# Every PyPI release gets a GitHub Release page

Closes the gap noticed after v0.4.0/v0.4.1: tags + PyPI publishes existed but no Release pages (this sandbox can't reach the Releases API, and the runbook's tag+dispatch fallback skipped the page).

- **publish.yml**: after publishing, auto-creates the GitHub Release from the annotated tag's message (`gh` on the runner; `contents: write`). No-op when the run was triggered by an actual release. `uv publish` gains `--check-url` so re-runs are idempotent instead of failing on existing files.
- **github-release.yml** (new, `workflow_dispatch` with a `tag` input): backfills a Release page for an existing annotated tag — will be dispatched for v0.4.0 and v0.4.1 immediately after this merges.
- Runbook in docs/publishing.md updated; same change rolling out to kash-docs, kash-media, and deep-transcribe for process consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A1qFxAyCavCMBvDWy8xJx7

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1qFxAyCavCMBvDWy8xJx7)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Raises `contents: write` on the publish workflow and changes release/PyPI automation; mistakes could create wrong releases or affect publish behavior, though steps are guarded and idempotent.
> 
> **Overview**
> **PyPI publishes now get a matching GitHub Release page** when the publish workflow runs on a tag, using the annotated tag message as release notes. The publish job gains `contents: write` and a post-publish step that calls `gh release create` only if the release does not already exist (normal `release` triggers stay a no-op).
> 
> **Publishing is idempotent:** `uv publish` uses `--check-url https://pypi.org/simple/` so re-runs skip artifacts already on PyPI instead of failing.
> 
> A new **`github-release.yml`** workflow (`workflow_dispatch` + tag input) backfills Release pages for existing annotated tags; it fails fast if the tag has no annotation message.
> 
> **`docs/publishing.md`** documents the tag+dispatch path (auto Release + idempotent publish) and points to `github-release.yml` for older tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f91324dfe4c68ec05110df6ac216bc87c4166000. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->