### PR TITLE
Resolve cached workspace resources correctly

### DIFF
--- a/src/kash/web_content/file_cache_utils.py
+++ b/src/kash/web_content/file_cache_utils.py
@@ -101,6 +101,11 @@ def cache_resource(
         if not ext_path.is_file():
             raise FileNotFound(f"External path not found: {ext_path}")
         cache_result = cache_file(ext_path, global_cache, expiration_sec)
+    elif item.store_path:
+        stored_path = item.absolute_path()
+        if not stored_path.is_file():
+            raise FileNotFound(f"Workspace resource not found: {stored_path}")
+        cache_result = cache_file(stored_path, global_cache, expiration_sec)
     elif item.original_filename:
         orig_path = Path(item.original_filename)
         if not orig_path.is_file():

--- a/tests/web_content/test_local_file_cache_integration.py
+++ b/tests/web_content/test_local_file_cache_integration.py
@@ -6,7 +6,12 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
 
+from kash.model import Format, Item, ItemType
+from kash.model.media_model import MediaType
+from kash.web_content.file_cache_utils import cache_resource
 from kash.web_content.local_file_cache import (
     Loadable,
     LocalFileCache,
@@ -120,6 +125,30 @@ class TestLocalFileCachePaths:
         assert result.content.path.read_text() == "local file data"
         # Cached file should be in cache dir, not the original.
         assert str(result.content.path).startswith(str(cache_dir))
+
+    def test_cache_resource_resolves_workspace_store_path(self, tmp_path):
+        workspace_dir = tmp_path / "workspace"
+        resource_path = workspace_dir / "resources/recording.resource.mp4"
+        resource_path.parent.mkdir(parents=True)
+        resource_path.write_bytes(b"\x00\x00\x00\x18ftypmp42")
+        item = Item(
+            type=ItemType.resource,
+            format=Format.mp4,
+            store_path="resources/recording.resource.mp4",
+            original_filename=resource_path.name,
+        )
+        cache = LocalFileCache(tmp_path / "cache", default_expiration_sec=NEVER)
+
+        with (
+            patch("kash.web_content.file_cache_utils._content_cache", cache),
+            patch(
+                "kash.workspaces.current_ws",
+                return_value=SimpleNamespace(base_dir=workspace_dir),
+            ),
+        ):
+            paths = cache_resource(item)
+
+        assert paths[MediaType.video].read_bytes() == resource_path.read_bytes()
 
 
 class TestReadMtime:


### PR DESCRIPTION
## What changed

- resolve imported resources from their workspace `store_path` before falling back to a legacy original filename
- add a regression test for a local MP4 whose original filename is only a basename and whose process cwd is outside the workspace

## Root cause

Imported resource items retain both a workspace-relative `store_path` and a basename-only `original_filename`. `cache_resource` ignored the stored workspace path, interpreted the basename relative to the caller's cwd, and caused `insert_frame_captures` to fail after an otherwise successful transcription.

## Validation

- focused local MP4 cache regression test
- `make lint`
- `make test` (310 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to resource resolution order in caching with a focused regression test; no auth or data-model changes.
> 
> **Overview**
> **`cache_resource`** now resolves imported workspace resources through **`item.store_path`** (via **`absolute_path()`**) before falling back to **`original_filename`**.
> 
> Previously, items with both a workspace-relative store path and a basename-only original filename skipped the stored path and treated the basename relative to the process cwd, which broke caching (e.g. **`insert_frame_captures`** after transcription).
> 
> A local integration test covers an MP4 under **`resources/`** with cwd outside the workspace, asserting cached bytes match the workspace file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34f114e65e518eb54e4307c837b665d0002909e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->