### PR TITLE
Canonicalize media URLs before cache lookup

### DIFF
--- a/src/kash/media_base/media_cache.py
+++ b/src/kash/media_base/media_cache.py
@@ -110,6 +110,13 @@ class MediaCache(DirStore):
         for each media type (video or audio). Returns cached copies if available,
         unless `refetch` is True.
         """
+        canonical_url_or_slice = canonicalize_media_url(url_or_slice)
+        if not canonical_url_or_slice:
+            log.error("Unrecognized media, current services: %s", get_media_services())
+            raise InvalidInput(
+                "Unrecognized media URL (is this media service configured?): %s" % url_or_slice
+            )
+        url_or_slice = canonical_url_or_slice
         key = str(url_or_slice)  # Cache key is the URL (with slice fragment if present)
 
         # Extract base URL and slice information
@@ -216,3 +223,32 @@ class MediaCache(DirStore):
         if not transcript:
             raise UnexpectedError("No transcript found for: %s" % url_or_slice)
         return transcript
+
+
+## Tests
+
+
+def test_cache_reuses_media_for_equivalent_canonical_urls() -> None:
+    from tempfile import TemporaryDirectory
+    from unittest.mock import patch
+
+    share_url = Url("https://youtu.be/kq9Q9-U0vrc?si=tracking-token")
+    canonical_url = Url("https://www.youtube.com/watch?v=kq9Q9-U0vrc")
+
+    with TemporaryDirectory() as temp_dir:
+        media_cache = MediaCache(Path(temp_dir))
+        cached_video = media_cache.path_for(str(canonical_url), suffix=SUFFIX_MP4)
+        cached_video.write_bytes(b"cached-video")
+
+        with (
+            patch(
+                "kash.media_base.media_cache.canonicalize_media_url",
+                return_value=canonical_url,
+            ) as canonicalize,
+            patch("kash.media_base.media_cache.download_media_by_service") as download,
+        ):
+            result = media_cache.cache(share_url, media_types=[MediaType.video])
+
+    assert result == {MediaType.video: cached_video}
+    canonicalize.assert_called_once_with(share_url)
+    download.assert_not_called()


### PR DESCRIPTION
## Summary

- canonicalize recognized media URLs before media-cache key generation
- reuse cached media across equivalent share/watch URLs and tracking parameters
- return the existing actionable invalid-media error before download attempts
- add a regression test that proves a YouTube share URL reuses a canonical watch-URL video without calling the downloader

## Root cause

Transcription canonicalized its URL before caching, but direct media consumers such as frame capture called `MediaCache.cache` with the original share URL. The two stages therefore generated different cache keys and downloaded the same video twice.

## Validation

- `make lint`: 0 errors and 0 warnings
- `make test`: 311 passed
- annotated Deep Transcribe E2E reused both canonical audio and video for a `youtu.be` URL containing an `si` tracking parameter

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted alignment with transcribe(); main behavior change is earlier validation and fewer duplicate downloads, with no auth or data-model changes.
> 
> **Overview**
> **`MediaCache.cache`** now runs **`canonicalize_media_url`** up front (same as **`transcribe`**) so cache keys match across equivalent links (e.g. `youtu.be` + tracking params vs `youtube.com/watch`).
> 
> Unrecognized URLs raise **`InvalidInput`** with the existing “unrecognized media” message **before** any download attempt.
> 
> A regression test asserts a share URL hits an existing canonical watch-URL cache entry and does not call **`download_media_by_service`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 120b7d5702a85cf8d13eaaf94c765f8572f595d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->