### PR TITLE
fix: preserve transcript boundaries and polish timestamps

### DIFF
--- a/src/kash/media_base/timestamp_citations.py
+++ b/src/kash/media_base/timestamp_citations.py
@@ -28,6 +28,9 @@ CITATION = "citation"
 TIMESTAMP_LINK = "timestamp-link"
 """Inline class name for a timestamp link."""
 
+TIMESTAMP_ICON = "timestamp-icon"
+"""Inline class name for the decorative timestamp icon."""
+
 
 def add_citation_to_text(text: str, citation: str) -> str:
     return f"{text}{NBSP}{citation}"
@@ -62,8 +65,12 @@ def format_timestamp_citation(
         timestamp_url = timestamp_media_url(base_url, timestamp)
         formatted_timestamp = html_a(formatted_timestamp, timestamp_url)
 
+    formatted_icon = (
+        html_span(emoji, TIMESTAMP_ICON, attrs={"aria-hidden": "true"}) if emoji else ""
+    )
+
     return html_span(
-        f"{emoji}{formatted_timestamp}&nbsp;",
+        f"{formatted_icon}{formatted_timestamp}&nbsp;",
         [CITATION, TIMESTAMP_LINK],
         attrs={DATA_SOURCE_PATH: source_path, DATA_TIMESTAMP: f"{timestamp:.2f}"},
         safe=True,
@@ -83,3 +90,10 @@ def html_speaker_id_span(text: str, speaker_id: str, safe: bool = False) -> str:
 
 def test_format_timestamp_span():
     assert html_timestamp_span("text", 123.456) == '<span data-timestamp="123.46">text</span>'
+
+
+def test_format_timestamp_citation_marks_decorative_icon() -> None:
+    citation = format_timestamp_citation(None, "resources/video.yml", 123.456)
+
+    assert '<span class="timestamp-icon" aria-hidden="true">⏱️</span>' in citation
+    assert "02:03" in citation

--- a/src/kash/media_base/timestamp_citations.py
+++ b/src/kash/media_base/timestamp_citations.py
@@ -28,9 +28,6 @@ CITATION = "citation"
 TIMESTAMP_LINK = "timestamp-link"
 """Inline class name for a timestamp link."""
 
-TIMESTAMP_ICON = "timestamp-icon"
-"""Inline class name for the decorative timestamp icon."""
-
 
 def add_citation_to_text(text: str, citation: str) -> str:
     return f"{text}{NBSP}{citation}"
@@ -57,20 +54,15 @@ def add_citation_to_sentence(
     )
 
 
-def format_timestamp_citation(
-    base_url: Url | None, source_path: str, timestamp: float, emoji: str = "⏱️"
-) -> str:
+def format_timestamp_citation(base_url: Url | None, source_path: str, timestamp: float) -> str:
     formatted_timestamp = format_timestamp(timestamp)
     if base_url:
         timestamp_url = timestamp_media_url(base_url, timestamp)
-        formatted_timestamp = html_a(formatted_timestamp, timestamp_url)
-
-    formatted_icon = (
-        html_span(emoji, TIMESTAMP_ICON, attrs={"aria-hidden": "true"}) if emoji else ""
-    )
+        if timestamp_url != base_url:
+            formatted_timestamp = html_a(formatted_timestamp, timestamp_url)
 
     return html_span(
-        f"{formatted_icon}{formatted_timestamp}&nbsp;",
+        f"{formatted_timestamp}&nbsp;",
         [CITATION, TIMESTAMP_LINK],
         attrs={DATA_SOURCE_PATH: source_path, DATA_TIMESTAMP: f"{timestamp:.2f}"},
         safe=True,
@@ -92,8 +84,35 @@ def test_format_timestamp_span():
     assert html_timestamp_span("text", 123.456) == '<span data-timestamp="123.46">text</span>'
 
 
-def test_format_timestamp_citation_marks_decorative_icon() -> None:
-    citation = format_timestamp_citation(None, "resources/video.yml", 123.456)
+def test_format_timestamp_citation_leaves_local_media_unlinked() -> None:
+    from pathlib import Path
+    from tempfile import TemporaryDirectory
 
-    assert '<span class="timestamp-icon" aria-hidden="true">⏱️</span>' in citation
+    from kash.utils.common.url import as_file_url
+
+    with TemporaryDirectory() as temp_dir:
+        media_path = Path(temp_dir) / "video.mp4"
+        media_path.touch()
+
+        citation = format_timestamp_citation(
+            as_file_url(media_path), "resources/video.yml", 123.456
+        )
+
     assert "02:03" in citation
+    assert "⏱️" not in citation
+    assert "<a " not in citation
+
+
+def test_format_timestamp_citation_links_seekable_web_media() -> None:
+    from unittest.mock import patch
+
+    base_url = Url("https://example.com/video")
+    timestamp_url = Url("https://example.com/video?t=123")
+
+    with patch(
+        "kash.media_base.timestamp_citations.timestamp_media_url", return_value=timestamp_url
+    ):
+        citation = format_timestamp_citation(base_url, "resources/video.yml", 123.456)
+
+    assert '<a href="https://example.com/video?t=123">02:03</a>' in citation
+    assert "⏱️" not in citation

--- a/src/kash/media_base/transcription_format.py
+++ b/src/kash/media_base/transcription_format.py
@@ -59,17 +59,56 @@ def format_speaker_segments(speaker_segments: list[SpeakerSegment]) -> str:
     ids and timestamps.
     """
 
-    # Use \n\n for readability between segments so each speaker is its own
-    # paragraph.
-    SEGMENT_SEP = "\n\n"
-
     speakers = set(segment.speaker for segment in speaker_segments)
     if len(speakers) > 1:
-        lines = []
+        turns: list[str] = []
+        previous_speaker: int | None = None
         for segment in speaker_segments:
-            lines.append(
-                f"{html_speaker_id_span(f'SPEAKER {segment.speaker}:', str(segment.speaker))}\n{_format_words(segment.words)}"
-            )
-        return SEGMENT_SEP.join(lines)
+            segment_text = _format_words(segment.words)
+            if segment.speaker == previous_speaker:
+                turns[-1] += f"\n{segment_text}"
+            else:
+                turns.append(
+                    f"{html_speaker_id_span(f'SPEAKER {segment.speaker}:', str(segment.speaker))}\n{segment_text}"
+                )
+                previous_speaker = segment.speaker
+        return "\n\n".join(turns)
     else:
-        return SEGMENT_SEP.join(_format_words(segment.words) for segment in speaker_segments)
+        return "\n".join(_format_words(segment.words) for segment in speaker_segments)
+
+
+## Tests
+
+
+def test_format_words_uses_single_line_breaks_between_sentences() -> None:
+    formatted = _format_words(
+        [
+            (1.0, "First"),
+            (1.5, "sentence."),
+            (2.0, "Second"),
+            (2.5, "sentence."),
+        ]
+    )
+
+    assert formatted == (
+        '<span data-timestamp="1.50">First sentence.</span>\n'
+        '<span data-timestamp="2.50">Second sentence.</span>'
+    )
+
+
+def test_format_speaker_segments_uses_paragraph_breaks_only_for_speaker_changes() -> None:
+    segments = [
+        SpeakerSegment([(1.0, "First.")], 1.0, 1.5, 0, 0.9),
+        SpeakerSegment([(2.0, "Still"), (2.5, "speaking.")], 2.0, 2.5, 0, 0.9),
+        SpeakerSegment([(3.0, "Reply.")], 3.0, 3.5, 1, 0.9),
+    ]
+
+    formatted = format_speaker_segments(segments)
+
+    assert formatted.count("SPEAKER 0:") == 1
+    assert formatted.count("SPEAKER 1:") == 1
+    assert (
+        '<span data-timestamp="1.00">First.</span>\n'
+        '<span data-timestamp="2.50">Still speaking.</span>'
+    ) in formatted
+    assert '</span>\n\n<span class="speaker-label" data-speaker-id="1">' in formatted

--- a/src/kash/web_gen/templates/content_styles.css.jinja
+++ b/src/kash/web_gen/templates/content_styles.css.jinja
@@ -30,6 +30,22 @@
   color: var(--color-primary);
 }
 
+.timestamp-link,
+.timestamp-link:hover {
+  background-color: transparent;
+  color: var(--color-secondary);
+}
+
+.timestamp-link a,
+.timestamp-link a:visited {
+  color: inherit;
+  text-decoration: none;
+}
+
+.timestamp-link a:hover {
+  text-decoration: underline;
+}
+
 {# Useful for debugging chunking #}
 {# .chunk {
   padding-top: 0.5rem;


### PR DESCRIPTION
## Summary

- keep sentence-level ASR spans on single line breaks and reserve paragraph breaks for speaker changes
- avoid repeated labels when adjacent provider segments belong to the same speaker
- omit the decorative clock glyph and only link genuinely seekable timestamp URLs
- render timestamp text and brackets in matching 8pt light-gray sans-serif type for print
- remove the trailing nonbreaking space that left a gap before the closing bracket

## Related PRs

- https://github.com/jlevy/kash-media/pull/7 handles provider-fragment spacing and frame placement
- https://github.com/jlevy/deep-transcribe/pull/12 integrates the behavior into the transcription workflow and PDF output

Kash Media #7 and this PR can merge in either order. Both should land before the coordinated Deep Transcribe release.

## Validation

- focused transcription-format and timestamp-citation tests passed
- three timestamp-citation tests passed against the local Kash source
- Ruff check and format passed
- coordinated browser PDF output passed visual validation