### PR TITLE
fix: tighten printed timestamp citations

### DIFF
--- a/src/kash/media_base/timestamp_citations.py
+++ b/src/kash/media_base/timestamp_citations.py
@@ -62,7 +62,7 @@ def format_timestamp_citation(base_url: Url | None, source_path: str, timestamp:
             formatted_timestamp = html_a(formatted_timestamp, timestamp_url)
 
     return html_span(
-        f"{formatted_timestamp}&nbsp;",
+        formatted_timestamp,
         [CITATION, TIMESTAMP_LINK],
         attrs={DATA_SOURCE_PATH: source_path, DATA_TIMESTAMP: f"{timestamp:.2f}"},
         safe=True,
@@ -101,6 +101,7 @@ def test_format_timestamp_citation_leaves_local_media_unlinked() -> None:
     assert "02:03" in citation
     assert "⏱️" not in citation
     assert "<a " not in citation
+    assert "&nbsp;" not in citation
 
 
 def test_format_timestamp_citation_links_seekable_web_media() -> None:
@@ -116,3 +117,4 @@ def test_format_timestamp_citation_links_seekable_web_media() -> None:
 
     assert '<a href="https://example.com/video?t=123">02:03</a>' in citation
     assert "⏱️" not in citation
+    assert "&nbsp;" not in citation

--- a/src/kash/web_gen/templates/content_styles.css.jinja
+++ b/src/kash/web_gen/templates/content_styles.css.jinja
@@ -46,6 +46,15 @@
   text-decoration: underline;
 }
 
+@media print {
+  .timestamp-link,
+  .timestamp-link:hover {
+    color: var(--color-tertiary) !important;
+    font-family: var(--font-sans) !important;
+    font-size: 8pt;
+  }
+}
+
 {# Useful for debugging chunking #}
 {# .chunk {
   padding-top: 0.5rem;


### PR DESCRIPTION
## Summary

- render timestamp text and brackets in matching 8pt light-gray sans-serif type for print
- remove the trailing nonbreaking space that left a visible gap before the closing bracket
- keep local timestamps plain while preserving seekable web links

## Related PRs

- https://github.com/jlevy/kash-media/pull/7 keeps frames outside timestamp spans
- https://github.com/jlevy/deep-transcribe/pull/12 integrates the behavior into the transcription workflow and PDF output

## Validation

- three focused timestamp-citation tests passed against the local Kash source
- coordinated browser PDF output passed visual validation on first, middle, and final pages