### PR TITLE
fix: break the FileStore import cycle

### DIFF
--- a/src/kash/exec/combiners.py
+++ b/src/kash/exec/combiners.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import TypeAlias
 
 from chopdiff.divs import GROUP, ORIGINAL, div, div_insert_wrapped
 from chopdiff.divs.parse_divs import parse_divs_single
@@ -10,6 +9,7 @@ from flexdoc.html.html_in_md import Wrapper
 
 from kash.config.logger import get_logger
 from kash.model.actions_model import ActionResult
+from kash.model.compound_actions_model import Combiner
 from kash.model.items_model import Item, ItemRelations, ItemType
 from kash.model.operations_model import OperationSummary
 from kash.model.paths_model import StorePath
@@ -17,8 +17,6 @@ from kash.utils.common.type_utils import not_none
 from kash.utils.errors import InvalidInput
 
 log = get_logger(__name__)
-
-Combiner: TypeAlias = Callable[[list[Item], list[ActionResult]], Item]
 
 
 def combine_items(

--- a/src/kash/model/compound_actions_model.py
+++ b/src/kash/model/compound_actions_model.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from textwrap import dedent
+from typing import TypeAlias
 
 from pydantic.dataclasses import dataclass
 from typing_extensions import override
 
 from kash.config.logger import get_logger
-from kash.exec.combiners import Combiner
 from kash.model.actions_model import Action, ActionInput, ActionResult
 from kash.model.exec_model import ActionContext
 from kash.model.items_model import Item, State
@@ -18,6 +18,8 @@ from kash.utils.common.type_utils import not_none
 from kash.utils.errors import InvalidInput
 
 log = get_logger(__name__)
+
+Combiner: TypeAlias = Callable[[list[Item], list[ActionResult]], Item]
 
 
 def look_up_actions(action_names: Iterable[str]) -> list[type[Action]]:

--- a/tests/file_storage/test_file_store.py
+++ b/tests/file_storage/test_file_store.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -15,6 +18,33 @@ from kash.model.items_model import Format, Item, ItemType
 from kash.model.operations_model import OperationSummary
 from kash.model.paths_model import StorePath
 from kash.utils.common.url import Url
+
+
+def test_file_store_import_survives_namespace_initializer() -> None:
+    project_root = Path(__file__).parents[2]
+    with tempfile.TemporaryDirectory() as temp_dir:
+        namespace_root = Path(temp_dir)
+        kash_package = namespace_root / "kash"
+        kash_package.mkdir()
+        (kash_package / "__init__.py").write_text(
+            '__path__ = __import__("pkgutil").extend_path(__path__, __name__)\n'
+        )
+        env = os.environ.copy()
+        env["PYTHONPATH"] = os.pathsep.join([str(namespace_root), str(project_root / "src")])
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from kash.file_storage.file_store import FileStore; print(FileStore.__name__)",
+            ],
+            cwd=project_root,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "FileStore"
 
 
 @dataclass


### PR DESCRIPTION
## Summary

- Move the `Combiner` type boundary into the compound-action model so model initialization no longer imports the execution package.
- Preserve `kash.exec.combiners.Combiner` as the existing public import path through a direct re-export.
- Add a subprocess regression that reproduces the minimal namespace initializer used by Kash extension wheels and verifies a direct `FileStore` import.

## Why

When a minimal or temporarily missing top-level Kash initializer exposed the raw import graph, `FileStore` initialized `kash.model`, which imported compound actions, which imported execution combiners, which loaded action execution and attempted to import the partially initialized `FileStore` again. The result depended on wheel installation order.

## Validation

- Regression failed before the fix and passes after it.
- `make install`
- `make lint`
- `make test` (316 passed)
- `uv build --no-build-isolation --python .venv/bin/python`
- Installed the built wheel in isolation and imported Kash’s public `Item`, direct `FileStore`, and `kash.exec.combiners.Combiner`.
