### PR TITLE
fix: preserve deterministic action cache identity

### DIFF
--- a/src/kash/actions/core/strip_html.py
+++ b/src/kash/actions/core/strip_html.py
@@ -10,7 +10,10 @@ from kash.utils.errors import InvalidInput
 log = get_logger(__name__)
 
 
-@kash_action(precondition=has_html_body | has_simple_text_body)
+@kash_action(
+    precondition=has_html_body | has_simple_text_body,
+    output_format=Format.markdown,
+)
 def strip_html(item: Item) -> Item:
     """
     Strip HTML tags from HTML or Markdown. This is a simple filter, simply searching
@@ -24,3 +27,13 @@ def strip_html(item: Item) -> Item:
     output_item = item.derived_copy(format=Format.markdown, body=clean_body)
 
     return output_item
+
+
+## Tests
+
+
+def test_strip_html_declares_markdown_output() -> None:
+    action_class = getattr(strip_html, "__action_class__")  # noqa: B009
+    action = action_class.create(None)
+
+    assert action.output_format is Format.markdown

--- a/src/kash/exec/action_exec.py
+++ b/src/kash/exec/action_exec.py
@@ -181,6 +181,8 @@ def run_action_operation(
 
     # Record the operation and add to the history of each item.
     for i, item in enumerate(result.items):
+        if i in result.skipped_indexes:
+            continue
         # A per-item action should be recorded as if it ran on each item individually.
         if action.run_per_item:
             this_op = replace(operation, arguments=[operation.arguments[i]])
@@ -231,6 +233,7 @@ def _run_for_each_item(context: ActionContext, input: ActionInput) -> ActionResu
 
     with task_stack().context(action.name, len(items), "item") as ts:
         result_items: list[Item] = []
+        skipped_indexes: set[int] = set()
         errors: list[Exception] = []
         multiple_inputs = len(items) > 1
 
@@ -249,6 +252,7 @@ def _run_for_each_item(context: ActionContext, input: ActionInput) -> ActionResu
             except SkipItem:
                 log.info("Caught SkipItem exception, skipping run on this item")
                 result_items.append(item)
+                skipped_indexes.add(len(result_items) - 1)
                 continue
             except get_nonfatal_exceptions() as e:
                 errors.append(e)
@@ -276,7 +280,7 @@ def _run_for_each_item(context: ActionContext, input: ActionInput) -> ActionResu
     if len(result_items) < 1:
         raise ContentError(f"Action `{action.name}` returned no items")
 
-    return ActionResult(result_items)
+    return ActionResult(result_items, skipped_indexes=skipped_indexes)
 
 
 def save_action_result(
@@ -302,7 +306,9 @@ def save_action_result(
     input_items = action_input.items
 
     skipped_paths = []
-    for item in result.items:
+    for index, item in enumerate(result.items):
+        if index in result.skipped_indexes:
+            continue
         if result.skip_duplicates:
             store_path = ws.find_by_id(item)
             if store_path:

--- a/src/kash/model/actions_model.py
+++ b/src/kash/model/actions_model.py
@@ -112,6 +112,9 @@ class ActionResult:
     shell_result: ShellResult | None = None
     """Customize control of how the action's result is displayed in the shell."""
 
+    skipped_indexes: set[int] = field(default_factory=set)
+    """Result positions passed through unchanged because a per-item action skipped them."""
+
     def get_by_format(self, *formats: Format) -> Item:
         """Convenience method to get an item for actions that return multiple formats."""
         return next(item for item in self.items if item.format in formats)

--- a/src/kash/model/operations_model.py
+++ b/src/kash/model/operations_model.py
@@ -158,7 +158,8 @@ class Operation:
     def as_str(self):
         args_str = ",".join(self.hashed_args())
         options_str = ",".join(
-            format_key_value(k, v, value_formatter=shell_quote) for k, v in self.options.items()
+            format_key_value(k, self.options[k], value_formatter=shell_quote)
+            for k in sorted(self.options)
         )
         if options_str:
             options_str = ";" + options_str

--- a/tests/exec/test_action_exec_integration.py
+++ b/tests/exec/test_action_exec_integration.py
@@ -12,12 +12,16 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from kash.exec.action_exec import SkipItem, run_action_operation, save_action_result
 from kash.exec_model.args_model import NO_ARGS, ONE_OR_MORE_ARGS
 from kash.model.actions_model import (
     Action,
+    ActionInput,
     ActionResult,
 )
+from kash.model.exec_model import ActionContext
 from kash.model.items_model import Item, ItemType
+from kash.model.operations_model import Operation
 from kash.run import kash_run
 from kash.utils.file_utils.file_formats_model import Format
 
@@ -207,3 +211,34 @@ class TestActionExecPipeline:
         assert result.items[0].body == "generated"
         action_input = mock_cls.create.return_value.run.call_args[0][0]
         assert action_input.items == []
+
+
+def test_skipped_item_preserves_source_and_is_not_saved() -> None:
+    item = Item(
+        type=ItemType.doc,
+        title="Input",
+        body="Already formatted.",
+        format=Format.markdown,
+        store_path="docs/input.doc.md",
+    )
+    original_source = item.source
+    action = MagicMock(spec=Action)
+    action.name = "noop"
+    action.run_per_item = True
+    action.cacheable = True
+    action.run.side_effect = SkipItem()
+    action_input = ActionInput([item])
+    operation = Operation("noop", [], {})
+    context = MagicMock(spec=ActionContext)
+    context.action = action
+    context.settings = MagicMock()
+
+    result = run_action_operation(context, action_input, operation)
+
+    assert result.items == [item]
+    assert result.skipped_indexes == {0}
+    assert item.source is original_source
+
+    workspace = MagicMock()
+    save_action_result(workspace, result, action_input)
+    workspace.save.assert_not_called()

--- a/tests/model/test_operations.py
+++ b/tests/model/test_operations.py
@@ -1,0 +1,30 @@
+from kash.model.operations_model import Input, Operation
+from kash.model.paths_model import StorePath
+
+
+def test_operation_identity_canonicalizes_option_order() -> None:
+    input_item = Input(StorePath("resources/watch.resource.yml"), "sha1:fixture")
+    declared = Operation(
+        action_name="transcribe",
+        arguments=[input_item],
+        options={
+            "language": "en",
+            "transcription_model": "nova-3",
+            "diarize_model": "latest",
+            "key_terms": "Hotel Check In",
+        },
+    )
+    reloaded = Operation.from_dict(
+        {
+            "action_name": "transcribe",
+            "arguments": [input_item.parseable_str()],
+            "options": {
+                "diarize_model": "latest",
+                "key_terms": "Hotel Check In",
+                "language": "en",
+                "transcription_model": "nova-3",
+            },
+        }
+    )
+
+    assert declared.as_str() == reloaded.as_str()


### PR DESCRIPTION
## Summary

Make Kash action cache identities deterministic across in-memory construction and YAML reloads. Preserve upstream lineage when a per-item action skips work, and declare the actual Markdown output of HTML stripping so cache preassembly can find prior results.

## Changes

- Sort operation option keys when rendering cache identity.
- Track skipped per-item results without rewriting their source metadata or resaving them.
- Declare `strip_html` output as Markdown.
- Add focused regression coverage for option ordering, skipped lineage, and output preassembly.

## Test Plan

- [x] Codespell, Ruff check, and Ruff format pass across the repository.
- [x] Ten focused operation, executor, and action tests pass against this source checkout.
- [ ] GitHub CI runs the full locked test, type-check, and build matrix.
- [ ] Deep Transcribe instruction-only rerun reuses the raw and formatting cache chain.

## Related Beads

- `dt-o0wa`
- `dt-89d3`
- `dt-ceik`