### PR TITLE
feat: preserve media discovery metadata

### DIFF
--- a/src/kash/model/items_model.py
+++ b/src/kash/model/items_model.py
@@ -469,7 +469,11 @@ class Item:
                 "media_id": media_metadata.media_id,
                 "media_service": media_metadata.media_service,
                 "upload_date": media_metadata.upload_date,
+                "channel": media_metadata.channel,
+                "uploader": media_metadata.uploader,
                 "channel_url": media_metadata.channel_url,
+                "categories": media_metadata.categories,
+                "tags": media_metadata.tags,
                 "view_count": media_metadata.view_count,
                 "duration": media_metadata.duration,
                 "heatmap": media_metadata.heatmap,
@@ -1140,3 +1144,22 @@ def test_item_context_metadata_round_trip_and_derivation():
     assert derived.additional_context == item.additional_context
     assert derived.extra == item.extra
     assert "Alice facilitates" in derived.prompt_context()
+
+
+def test_item_preserves_media_discovery_metadata() -> None:
+    metadata = MediaMetadata(
+        title="Hotel Check In - SNL",
+        url=Url("https://www.youtube.com/watch?v=abcdefghijk"),
+        channel="Saturday Night Live",
+        uploader="Saturday Night Live",
+        categories=["Entertainment"],
+        tags=["SNL", "comedy", "hotel"],
+    )
+
+    item = Item.from_media_metadata(metadata)
+
+    assert item.extra is not None
+    assert item.extra["channel"] == "Saturday Night Live"
+    assert item.extra["uploader"] == "Saturday Night Live"
+    assert item.extra["categories"] == ["Entertainment"]
+    assert item.extra["tags"] == ["SNL", "comedy", "hotel"]

--- a/src/kash/model/media_model.py
+++ b/src/kash/model/media_model.py
@@ -62,7 +62,11 @@ class MediaMetadata:
 
     # Extra media fields.
     upload_date: date | None = None
+    channel: str | None = None
+    uploader: str | None = None
     channel_url: Url | None = None
+    categories: list[str] | None = None
+    tags: list[str] | None = None
     view_count: int | None = None
     duration: int | None = None
     heatmap: list[HeatmapValue] | None = None


### PR DESCRIPTION
## Summary

Extend `MediaMetadata` with optional channel, uploader, category, and tag fields, and
preserve them in URL resource item metadata. This lets media kits retain bounded
discovery context from extractors without putting extractor-specific code in Kash core.

## Changes

- Add `channel`, `uploader`, `categories`, and `tags` to `MediaMetadata`.
- Carry them through `Item.from_media_metadata` into `Item.extra`.
- Cover the complete metadata transfer into `Item.extra`.

## Test Plan

- [x] `make lint-check`
- [x] `make test` (320 tests)
- [x] CI green on 3.11 through 3.14
- [x] Consumed end to end by a stacked Deep Transcribe run: the saved resource carries
      `channel`, `categories`, and `tags`, and they reach the semantic prompts

## Release order

This is the head of a four-repo chain and nothing downstream can move until it ships.

1. Merge and tag **kash-shell v0.4.10** (this PR)
2. kash-docs needs **no release** — 0.2.7 already allows `kash-shell>=0.4.9,<0.5`
3. jlevy/kash-media#11: relock, undraft, merge, tag v0.4.8. It adds a direct
   `kash-shell>=0.4.10` floor, because `MediaMetadata` is a plain dataclass and the new
   keyword arguments raise `TypeError` against 0.4.9
4. jlevy/deep-transcribe#16: bump the kash-media floor, tag v0.1.14
